### PR TITLE
ghcr image refs + dev/prod toggle

### DIFF
--- a/charts/digiusher-k8s-agent/Chart.yaml
+++ b/charts/digiusher-k8s-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digiusher-k8s-agent/templates/_helpers.tpl
+++ b/charts/digiusher-k8s-agent/templates/_helpers.tpl
@@ -57,7 +57,10 @@ Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global)
 */}}
 {{- define "digiusher-k8s-agent.image" -}}
 {{- if .global.useDevImages -}}
-{{ .image.devRepository }}:{{ .image.devTag | default .image.tag }}
+{{- if not .image.devTag -}}
+{{- fail "global.useDevImages=true but image.devTag is empty. Set it to a SHA, e.g. --set <svc>.image.devTag=<sha>. The *-dev packages have no `latest` tag." -}}
+{{- end -}}
+{{ .image.devRepository }}:{{ .image.devTag }}
 {{- else -}}
 {{ .image.repository }}:{{ .image.tag }}
 {{- end -}}

--- a/charts/digiusher-k8s-agent/templates/_helpers.tpl
+++ b/charts/digiusher-k8s-agent/templates/_helpers.tpl
@@ -52,6 +52,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Resolve image reference based on global.useDevImages.
+Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global)
+*/}}
+{{- define "digiusher-k8s-agent.image" -}}
+{{- if .global.useDevImages -}}
+{{ .image.devRepository }}:{{ .image.devTag | default .image.tag }}
+{{- else -}}
+{{ .image.repository }}:{{ .image.tag }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "digiusher-k8s-agent.serviceAccountName" -}}

--- a/charts/digiusher-k8s-agent/templates/api/api-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/api/api-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: "{{ include "digiusher-k8s-agent.image" (dict "image" .Values.api.image "global" .Values.global) }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/digiusher-k8s-agent/templates/uploader/uploader-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/uploader/uploader-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.uploader.image.repository }}:{{ .Values.uploader.image.tag }}"
+          image: "{{ include "digiusher-k8s-agent.image" (dict "image" .Values.uploader.image "global" .Values.global) }}"
           imagePullPolicy: {{ .Values.uploader.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -42,11 +42,14 @@ api:
     devRepository: ghcr.io/digiusher/digiusher-k8s-api-dev
     pullPolicy: Always
     tag: "latest"
-    # Override with a SHA when global.useDevImages=true (the *-dev package has no `latest` tag).
-    devTag: "latest"
+    # Required when global.useDevImages=true. The *-dev package has no `latest` tag,
+    # so this must be set to a SHA via --set api.image.devTag=<sha>.
+    devTag: ""
   nameOverride: ""
   fullnameOverride: ""
   podAnnotations: {}
+  # API runs distroless `nonroot` (UID 65532). Uploader uses UID 1001 — the
+  # difference is intentional, see the uploader block below.
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -127,11 +130,16 @@ uploader:
     devRepository: ghcr.io/digiusher/digiusher-k8s-uploader-dev
     pullPolicy: Always
     tag: "latest"
-    # Override with a SHA when global.useDevImages=true (the *-dev package has no `latest` tag).
-    devTag: "latest"
+    # Required when global.useDevImages=true. The *-dev package has no `latest` tag,
+    # so this must be set to a SHA via --set uploader.image.devTag=<sha>.
+    devTag: ""
   nameOverride: ""
   fullnameOverride: ""
   podAnnotations: {}
+  # Uploader image is python:3.12-slim (not distroless — Python + pyarrow native
+  # deps make a distroless base impractical and offer little real saving).
+  # The image creates an `app` user at UID 1001, hence the values below differ
+  # from the API's 65532. Keep them in sync with uploader/Dockerfile.
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -13,6 +13,12 @@ global:
     dev:
       enabled: false
   redis_url: "redis://digiusher-k8s-redis-svc:6379"
+  # Flip to true to pull the private *-dev images (CI workflow_dispatch builds)
+  # instead of the public prod ones. When true, populate global.imagePullSecrets
+  # with a secret that can authenticate to ghcr.io and override the per-service
+  # image.devTag with a real SHA (the *-dev packages don't carry a `latest` tag).
+  useDevImages: false
+  imagePullSecrets: []
 
 #########################################
 # Service Account
@@ -32,16 +38,19 @@ api:
   containerName: "digiusher-k8s-api"
   replicaCount: 1
   image:
-    repository: digiusher.azurecr.io/digiusher-k8s-api
+    repository: ghcr.io/digiusher/digiusher-k8s-api
+    devRepository: ghcr.io/digiusher/digiusher-k8s-api-dev
     pullPolicy: Always
     tag: "latest"
+    # Override with a SHA when global.useDevImages=true (the *-dev package has no `latest` tag).
+    devTag: "latest"
   nameOverride: ""
   fullnameOverride: ""
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
-    fsGroup: 1001
+    fsGroup: 65532
   securityContext:
     capabilities:
       drop:
@@ -49,7 +58,7 @@ api:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 1001
+    runAsUser: 65532
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   env:
     max_request_bytes: "20971520" # 20 MiB, minimum 1 MiB
@@ -114,9 +123,12 @@ uploader:
   containerName: "uploader"
   replicaCount: 1
   image:
-    repository: digiusher.azurecr.io/digiusher-k8s-uploader
+    repository: ghcr.io/digiusher/digiusher-k8s-uploader
+    devRepository: ghcr.io/digiusher/digiusher-k8s-uploader-dev
     pullPolicy: Always
     tag: "latest"
+    # Override with a SHA when global.useDevImages=true (the *-dev package has no `latest` tag).
+    devTag: "latest"
   nameOverride: ""
   fullnameOverride: ""
   podAnnotations: {}


### PR DESCRIPTION
## Summary

- Point `api`/`uploader` images at the public `ghcr.io/digiusher/digiusher-k8s-{api,uploader}` packages.
- Add `global.useDevImages` (default `false`). When `true`, the chart pulls the private `*-dev` packages instead — useful for testing CI builds before they land on the prod tag.
- New helper `digiusher-k8s-agent.image` resolves the repo/tag pair from `global.useDevImages` and fails fast (`helm fail`) if `devTag` is empty in dev mode.
- API `runAsUser`/`fsGroup` set to `65532` to match the distroless `nonroot` user the API image now runs as. Uploader stays on UID 1001 (different runtime base — see comments in `values.yaml`).

`*-dev` packages don't carry a `latest` tag, so dev users must override `devTag` with a real SHA.

## Usage

Default (public prod):
```
helm install digiusher-k8s ./charts/digiusher-k8s-agent -n digiusher-k8s --create-namespace \
  --set uploader.env.digiusher_k8s_api_token=<token>
```

Dev images (private):
```
kubectl create secret docker-registry ghcr-pull -n digiusher-k8s \
  --docker-server=ghcr.io --docker-username=<gh-user> --docker-password=<PAT>

helm install digiusher-k8s ./charts/digiusher-k8s-agent -n digiusher-k8s --create-namespace \
  --set global.useDevImages=true \
  --set api.image.devTag=<sha> \
  --set uploader.image.devTag=<sha> \
  --set 'global.imagePullSecrets[0].name=ghcr-pull' \
  --set uploader.env.digiusher_k8s_api_token=<token>
```

## Test plan
- [x] `helm lint` passes.
- [x] Default mode renders `ghcr.io/digiusher/digiusher-k8s-{api,uploader}:latest`.
- [x] `--set global.useDevImages=true --set <svc>.image.devTag=<sha>` renders the `-dev` repo with the SHA tag.
- [x] `--set global.useDevImages=true` with no `devTag` fails rendering with a clear error pointing the user at the right `--set` flag.
- [ ] Once the prod packages are flipped public, install on a clean kind cluster with no `imagePullSecrets` and confirm both deployments reach `Running`.
- [ ] In dev mode, install with a ghcr PAT secret, confirm pods reach `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)