### PR TITLE
fix: alloy regex (RE2) and redis PVC storageClassName re-render

### DIFF
--- a/charts/digiusher-k8s-agent/Chart.yaml
+++ b/charts/digiusher-k8s-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digiusher-k8s-agent/alloy-config.yaml
+++ b/charts/digiusher-k8s-agent/alloy-config.yaml
@@ -66,10 +66,15 @@ prometheus.relabel "cadvisor_relabler" {
     // For network metrics: only keep eth* interfaces (the node's primary NIC)
     // Drop CNI virtual interfaces (veth*, cali*, flannel*, cni0, tunl0, etc.) to avoid
     // double-counting intra-node traffic. eth* gives us the actual external traffic.
+    //
+    // Alloy uses RE2 (no negative lookahead). The character-class trio is the RE2
+    // idiom for "doesn't start with eth": first char != 'e', or e + non-'t', or
+    // et + non-'h'. Anything starting with literal "eth" falls through all three
+    // alternatives, the regex doesn't match, and the metric is kept.
     rule {
     action = "drop"
     source_labels = ["__name__", "interface"]
-    regex = "container_network_.*_bytes_total;(?!eth).+"
+    regex = "container_network_.*_bytes_total;([^e]|e[^t]|et[^h]).*"
     }
 }
 

--- a/charts/digiusher-k8s-agent/templates/redis/redis-pvc.yaml
+++ b/charts/digiusher-k8s-agent/templates/redis/redis-pvc.yaml
@@ -10,6 +10,8 @@ spec:
   resources:
     requests:
       storage: {{ .Values.redis.pvc.size }}
-  storageClassName: {{ .Values.redis.pvc.storageClassName }}
+  {{- with .Values.redis.pvc.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## Summary

Two bugs found while smoke-testing the chart on a real cluster.

### 1. Alloy CrashLoopBackOff — Perl regex in `alloy-config.yaml`

The drop rule for non-eth network interfaces used `(?!eth)`, Perl-style negative lookahead. Alloy uses Go's RE2 engine which doesn't support lookahead, so alloy crashed on startup with:

```
error parsing regexp: invalid or unsupported Perl syntax: `(?!`
```

Replaced with the RE2 idiom for "doesn't start with `eth`": `([^e]|e[^t]|et[^h]).*` — three alternatives covering each prefix-position mismatch. Anything starting with literal `eth` falls through and is preserved. Same intent (drop CNI virtual interfaces, keep eth*), no new dependency on enumerating CNI plugins.

### 2. `helm upgrade` fails with PVC immutability error

The redis PVC template emitted `storageClassName: ` (renders to null) when unset. On install, the cluster's default StorageClassController auto-fills the field (e.g. `standard-rwo` on GKE). On any subsequent `helm upgrade`, the re-rendered chart still shows null, diffs against the live value, and helm tries to patch — but `storageClassName` is immutable on bound PVCs, so:

```
PersistentVolumeClaim "..." is invalid: spec: Forbidden:
spec is immutable after creation except resources.requests
and volumeAttributesClassName for bound claims
```

Wrapped the field in `{{- with .Values.redis.pvc.storageClassName }}` so it's omitted entirely when unset. The cluster's auto-filled value is then left alone on upgrade. Users who do specify a class still get exactly what they configure.

Chart bumped to `0.0.4` so chart-releaser publishes the fix.

## Test plan

- [ ] Chart-releaser publishes 0.0.4
- [ ] `helm install` on a fresh cluster brings alloy to `Running` (no CrashLoopBackOff)
- [ ] `helm upgrade` on the same release succeeds (no PVC immutability error)
- [ ] `kubectl logs ... -c alloy` no longer shows the regex parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)