### PR TITLE
v0.3.0 — release-aware names, vmagent scraper, agent StatefulSet

### DIFF
--- a/charts/digiusher-k8s-agent/Chart.yaml
+++ b/charts/digiusher-k8s-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digiusher-k8s-agent/alloy-config.yaml
+++ b/charts/digiusher-k8s-agent/alloy-config.yaml
@@ -7,7 +7,7 @@ prometheus.scrape "ksm_scraper" {
     scrape_timeout = "10s"
     targets = [
     {
-        __address__ = "digiusher-k8s-kube-state-metrics.digiusher-k8s.svc.cluster.local:8080",
+        __address__ = "{{ include "digiusher-k8s-agent.ksm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080",
     },
     ]
     forward_to = [prometheus.relabel.ksm_relabler.receiver]
@@ -143,7 +143,7 @@ prometheus.remote_write "default" {
     }
 
     endpoint {
-    url = "http://digiusher-k8s-api-svc.digiusher-k8s.svc.cluster.local:8111/api/v1/write"
+    url = "http://{{ include "digiusher-k8s-agent.api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8111/api/v1/write"
     remote_timeout = "10s"
     metadata_config {
         send = false

--- a/charts/digiusher-k8s-agent/templates/_helpers.tpl
+++ b/charts/digiusher-k8s-agent/templates/_helpers.tpl
@@ -52,6 +52,54 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Per-component fullnames. Each chart-owned resource (Deployment, Service,
+ConfigMap, PVC, Secret) is named with these so it's release-prefixed and
+two installs in one namespace don't collide.
+*/}}
+{{- define "digiusher-k8s-agent.api.fullname" -}}
+{{- printf "%s-api" (include "digiusher-k8s-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "digiusher-k8s-agent.redis.fullname" -}}
+{{- printf "%s-redis" (include "digiusher-k8s-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "digiusher-k8s-agent.uploader.fullname" -}}
+{{- printf "%s-uploader" (include "digiusher-k8s-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "digiusher-k8s-agent.apiToken.secretName" -}}
+{{- printf "%s-api-token" (include "digiusher-k8s-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+KSM service name. Mirrors the kube-state-metrics subchart's own fullname
+output for any release name not containing "kube-state-metrics" and where
+KSM has no fullnameOverride — both reasonable assumptions for this chart.
+*/}}
+{{- define "digiusher-k8s-agent.ksm.fullname" -}}
+{{- printf "%s-kube-state-metrics" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+Per-component selector labels. Each Deployment selects only its own pods.
+*/}}
+{{- define "digiusher-k8s-agent.api.selectorLabels" -}}
+{{ include "digiusher-k8s-agent.selectorLabels" . }}
+app.kubernetes.io/component: api
+{{- end }}
+
+{{- define "digiusher-k8s-agent.redis.selectorLabels" -}}
+{{ include "digiusher-k8s-agent.selectorLabels" . }}
+app.kubernetes.io/component: redis
+{{- end }}
+
+{{- define "digiusher-k8s-agent.uploader.selectorLabels" -}}
+{{ include "digiusher-k8s-agent.selectorLabels" . }}
+app.kubernetes.io/component: uploader
+{{- end }}
+
+{{/*
 Resolve image reference based on global.useDevImages.
 Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global)
 */}}

--- a/charts/digiusher-k8s-agent/templates/alloy/alloy-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/alloy/alloy-configmap.yaml
@@ -3,13 +3,9 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.alloy.alloy.configMap.name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: alloy
 data:
   config.alloy: |
-    {{- .Files.Get "alloy-config.yaml" 
-        | replace "digiusher-k8s-kube-state-metrics" (printf "%s-kube-state-metrics" .Release.Name) 
-        | replace "digiusher-k8s.svc.cluster.local:8080" (printf "%s.svc.cluster.local:8080" .Release.Namespace)
-        | replace "digiusher-k8s-api-svc" (printf "%s-api-svc" .Release.Name) 
-        | replace "digiusher-k8s.svc.cluster.local:8111" (printf "%s.svc.cluster.local:8111" .Release.Namespace)
-        | trim 
-        | nindent 4 
-    }}
+    {{- tpl (.Files.Get "alloy-config.yaml") . | trim | nindent 4 }}

--- a/charts/digiusher-k8s-agent/templates/api/api-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/api/api-configmap.yaml
@@ -3,10 +3,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.api.name }}-cm
+  name: {{ include "digiusher-k8s-agent.api.fullname" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 data:
   {{- if .Values.redis.enabled }}
-  REDIS_URL: "redis://{{ .Values.redis.service.name }}:{{ .Values.redis.service.port }}"
+  REDIS_URL: "redis://{{ include "digiusher-k8s-agent.redis.fullname" . }}:{{ .Values.redis.service.port }}"
   {{- else }}
   REDIS_URL: {{ .Values.global.redis_url | quote }}
   {{- end }}

--- a/charts/digiusher-k8s-agent/templates/api/api-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/api/api-deployment.yaml
@@ -3,16 +3,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.api.name }}-deployment
+  name: {{ include "digiusher-k8s-agent.api.fullname" . }}
   labels:
     {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   {{- if not .Values.api.autoscaling.enabled }}
   replicas: {{ .Values.api.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Values.api.name }}
+      {{- include "digiusher-k8s-agent.api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.api.podAnnotations }}
@@ -20,14 +21,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "digiusher-k8s-agent.labels" . | nindent 8 }}
-        app: {{ .Values.api.name }}
+        {{- include "digiusher-k8s-agent.api.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "digiusher-k8s-agent.serviceAccountName" . }}
       {{- with .Values.api.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ .Values.api.name }}-cm
+                name: {{ include "digiusher-k8s-agent.api.fullname" . }}
           ports:
             - name: http
               containerPort: {{ .Values.api.service.port }}

--- a/charts/digiusher-k8s-agent/templates/api/api-hpa.yaml
+++ b/charts/digiusher-k8s-agent/templates/api/api-hpa.yaml
@@ -2,14 +2,15 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.api.name }}-hpa
+  name: {{ include "digiusher-k8s-agent.api.fullname" . }}
   labels:
-    app: {{ .Values.api.name }}
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.api.name }}-deployment
+    name: {{ include "digiusher-k8s-agent.api.fullname" . }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
   metrics:

--- a/charts/digiusher-k8s-agent/templates/api/api-service.yaml
+++ b/charts/digiusher-k8s-agent/templates/api/api-service.yaml
@@ -3,9 +3,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.api.service.name }}
+  name: {{ include "digiusher-k8s-agent.api.fullname" . }}
   labels:
-    app: {{ .Values.api.name }}
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
 spec:
   type: {{ .Values.api.service.type }}
   ports:
@@ -14,6 +15,6 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ .Values.api.name }}
+    {{- include "digiusher-k8s-agent.api.selectorLabels" . | nindent 4 }}
 
 {{- end }}

--- a/charts/digiusher-k8s-agent/templates/digiusher-secret.yaml
+++ b/charts/digiusher-k8s-agent/templates/digiusher-secret.yaml
@@ -2,7 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: digiusher-k8s-api-token
+  name: {{ include "digiusher-k8s-agent.apiToken.secretName" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   K8S_API_TOKEN: {{ .Values.uploader.env.digiusher_k8s_api_token | quote }}

--- a/charts/digiusher-k8s-agent/templates/redis/redis-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/redis/redis-deployment.yaml
@@ -3,16 +3,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.redis.name }}-deployment
+  name: {{ include "digiusher-k8s-agent.redis.fullname" . }}
   labels:
     {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
 spec:
   {{- if not .Values.redis.autoscaling.enabled }}
   replicas: {{ .Values.redis.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      app: {{ .Values.redis.name }}
+      {{- include "digiusher-k8s-agent.redis.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.redis.podAnnotations }}
@@ -20,16 +21,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "digiusher-k8s-agent.labels" . | nindent 8 }}
-        app: {{ .Values.redis.name }}
+        {{- include "digiusher-k8s-agent.redis.selectorLabels" . | nindent 8 }}
     spec:
-    {{/*  
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    */}}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "digiusher-k8s-agent.serviceAccountName" . }}
       {{- with .Values.redis.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -59,14 +53,13 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.redis.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.redis.volumes }}
+            - name: redis-storage
+              mountPath: /data
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - name: redis-storage
+          persistentVolumeClaim:
+            claimName: {{ include "digiusher-k8s-agent.redis.fullname" . }}
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/digiusher-k8s-agent/templates/redis/redis-pvc.yaml
+++ b/charts/digiusher-k8s-agent/templates/redis/redis-pvc.yaml
@@ -3,7 +3,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.redis.name }}-pvc
+  name: {{ include "digiusher-k8s-agent.redis.fullname" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
 spec:
   accessModes:
     - ReadWriteOnce

--- a/charts/digiusher-k8s-agent/templates/redis/redis-service.yaml
+++ b/charts/digiusher-k8s-agent/templates/redis/redis-service.yaml
@@ -3,9 +3,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.redis.service.name }}
+  name: {{ include "digiusher-k8s-agent.redis.fullname" . }}
   labels:
-    app: {{ .Values.redis.name }}
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
 spec:
   type: {{ .Values.redis.service.type }}
   ports:
@@ -14,6 +15,6 @@ spec:
       targetPort: {{ .Values.redis.service.port }}
       protocol: TCP
   selector:
-    app: {{ .Values.redis.name }}
+    {{- include "digiusher-k8s-agent.redis.selectorLabels" . | nindent 4 }}
 
 {{- end }}

--- a/charts/digiusher-k8s-agent/templates/serviceaccount.yaml
+++ b/charts/digiusher-k8s-agent/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "digiusher-k8s-agent.serviceAccountName" . }}
   labels:
     {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/digiusher-k8s-agent/templates/uploader/uploader-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/uploader/uploader-configmap.yaml
@@ -3,10 +3,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.uploader.name }}-cm
+  name: {{ include "digiusher-k8s-agent.uploader.fullname" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: uploader
 data:
   {{- if .Values.redis.enabled }}
-  REDIS_URL: "redis://{{ .Values.redis.service.name }}:{{ .Values.redis.service.port }}"
+  REDIS_URL: "redis://{{ include "digiusher-k8s-agent.redis.fullname" . }}:{{ .Values.redis.service.port }}"
   {{- else }}
   REDIS_URL: {{ .Values.global.redis_url | quote }}
   {{- end }}

--- a/charts/digiusher-k8s-agent/templates/uploader/uploader-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/uploader/uploader-deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.uploader.name }}-deployment
+  name: {{ include "digiusher-k8s-agent.uploader.fullname" . }}
   labels:
     {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: uploader
 spec:
   {{- if not .Values.uploader.autoscaling.enabled }}
   replicas: {{ .Values.uploader.replicaCount }}
@@ -14,7 +15,7 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: {{ .Values.uploader.name }}
+      {{- include "digiusher-k8s-agent.uploader.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.uploader.podAnnotations }}
@@ -22,14 +23,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "digiusher-k8s-agent.labels" . | nindent 8 }}
-        app: {{ .Values.uploader.name }}
+        {{- include "digiusher-k8s-agent.uploader.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "digiusher-k8s-agent.serviceAccountName" . }}
       {{- with .Values.uploader.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -44,12 +44,12 @@ spec:
           imagePullPolicy: {{ .Values.uploader.image.pullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ .Values.uploader.name }}-cm
+                name: {{ include "digiusher-k8s-agent.uploader.fullname" . }}
           env:
             - name: K8S_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: digiusher-k8s-api-token
+                  name: {{ include "digiusher-k8s-agent.apiToken.secretName" . }}
                   key: K8S_API_TOKEN
           {{- with .Values.uploader.livenessProbe }}
           livenessProbe:

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -12,7 +12,9 @@ global:
       grace_period_seconds: "120" # 2 minutes, minimum 30 seconds
     dev:
       enabled: false
-  redis_url: "redis://digiusher-k8s-redis-svc:6379"
+  # Used only when redis.enabled=false. Set this to your external redis
+  # endpoint. The default value is a placeholder and not a working URL.
+  redis_url: "redis://external-redis:6379"
   # Flip to true to pull the private *-dev images (CI workflow_dispatch builds)
   # instead of the public prod ones. When true, populate global.imagePullSecrets
   # with a secret that can authenticate to ghcr.io and override the per-service
@@ -27,14 +29,15 @@ serviceAccount:
   create: true
   automount: true
   annotations: {}
-  name: "digiusher-k8s-agent-sa"
+  # Leave empty to derive from the release name (recommended). Set explicitly
+  # only if you need to bind to a pre-existing ServiceAccount.
+  name: ""
 
 #########################################
 # API service configurations
 #########################################
 api:
   enabled: true
-  name: "digiusher-k8s-api"
   containerName: "digiusher-k8s-api"
   replicaCount: 1
   image:
@@ -66,7 +69,6 @@ api:
   env:
     max_request_bytes: "20971520" # 20 MiB, minimum 1 MiB
   service:
-    name: digiusher-k8s-api-svc
     type: ClusterIP
     port: 8111
   resources:
@@ -122,7 +124,6 @@ api:
 #########################################
 uploader:
   enabled: true
-  name: "digiusher-k8s-uploader"
   containerName: "uploader"
   replicaCount: 1
   image:
@@ -208,7 +209,6 @@ uploader:
 #########################################
 redis:
   enabled: true
-  name: "digiusher-k8s-redis"
   containerName: "digiusher-k8s-redis"
   replicaCount: 1
   image:
@@ -237,7 +237,6 @@ redis:
     size: 4Gi
     storageClassName: ""
   service:
-    name: digiusher-k8s-redis-svc
     type: ClusterIP
     port: 6379
   resources:
@@ -269,13 +268,6 @@ redis:
     maxReplicas: 6
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-  volumes:
-    - name: redis-storage
-      persistentVolumeClaim:
-        claimName: digiusher-k8s-redis-pvc
-  volumeMounts:
-    - name: redis-storage
-      mountPath: /data
   nodeSelector: {}
   tolerations:
     - key: "digiusher-k8s"


### PR DESCRIPTION
## Summary

Ships `digiusher-k8s-agent` **0.3.0**. Three layered changes that previously lived in separate stacked PRs, now consolidated here:

1. **Release-aware resource names (chart hardening).** Every chart-owned resource derives its name from the Helm release via per-component fullname helpers instead of hardcoded values, so the chart installs cleanly under any release name and two installs no longer collide in a namespace. Fixes the latent bug where the scraper looked for `<release>-api-svc` while the Service was created as `digiusher-k8s-api-svc`.

2. **vmagent scraper replaces the Alloy DaemonSet.** A single-replica vmagent Deployment runs the same scrape pipeline (kube-state-metrics, cAdvisor, kubelet volume stats) and forwards via Prometheus remote_write. ~30 bytes/active-series vs. Alloy's footprint, and one pod instead of one-per-node — none of these metrics need node-local access. Adds `templates/vmagent/` (Deployment, ConfigMap, ClusterRole/Binding, PVC) and a `vmagent:` values block with configurable `intervals` (ksm 25s / cadvisor 20s / kubelet 30s, all overridable).

3. **Agent StatefulSet replaces api + redis + uploader.** A single agent StatefulSet receives remote_write from vmagent, aggregates in memory, snapshots to a per-pod PV for crash recovery, builds parquet at window close, and uploads via pre-signed S3 URL. Adds `templates/agent/{agent-statefulset,agent-service,agent-configmap}.yaml`; retires `templates/{api,redis,uploader}`. vmagent's `-remoteWrite.url` retargets the agent's headless Service; `-remoteWrite.forcePromProto=true` avoids zstd-reject double-sends. Secret token now sources from `agent.env.digiusher_k8s_api_token`.

**Net bill of materials:** vmagent + kube-state-metrics + agent — 3 components, down from 5.

## Migration

Clean cutover — uninstall the 0.2.x / 0.0.x release before installing 0.3.0. The Deployment→StatefulSet workload-kind change blocks `helm upgrade` anyway. No pre-upgrade hooks, no compatibility flags. The redis buffer (short-lived working state) is not preserved; this is acceptable.

## Test plan

- [x] `helm lint charts/digiusher-k8s-agent` passes
- [x] `helm template <release> charts/digiusher-k8s-agent` renders correctly across multiple release names; no DaemonSet owned by this chart; vmagent `-remoteWrite.url` resolves to the agent's headless Service
- [x] `helm template … | kubectl apply --dry-run=client --validate=true`
- [x] Install on smoke cluster: agent pod Ready, vmagent + KSM Ready
- [x] vmagent → agent: zero decode errors after `forcePromProto`
- [x] ~18K samples ingested in ~2 min; metadata + metrics parquet built and uploaded
- [x] Pod kill → restart: all 8 shard snapshots restored from PV; `/readyz=200`
