### PR TITLE
chart 0.4.0: pin agent memory + broaden collection

### DIFF
--- a/charts/digiusher-k8s-agent/Chart.yaml
+++ b/charts/digiusher-k8s-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/digiusher-k8s-agent/templates/_helpers.tpl
+++ b/charts/digiusher-k8s-agent/templates/_helpers.tpl
@@ -92,7 +92,9 @@ app.kubernetes.io/component: vmagent
 
 {{/*
 Resolve image reference based on global.useDevImages.
-Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global)
+Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global "appVersion" .Chart.AppVersion)
+When image.tag is empty it falls back to the chart's appVersion (the
+released image version), so the shipped image is single-sourced in Chart.yaml.
 */}}
 {{- define "digiusher-k8s-agent.image" -}}
 {{- if .global.useDevImages -}}
@@ -101,7 +103,7 @@ Caller passes: (dict "image" .Values.<svc>.image "global" .Values.global)
 {{- end -}}
 {{ .image.devRepository }}:{{ .image.devTag }}
 {{- else -}}
-{{ .image.repository }}:{{ .image.tag }}
+{{ .image.repository }}:{{ .image.tag | default .appVersion }}
 {{- end -}}
 {{- end }}
 

--- a/charts/digiusher-k8s-agent/templates/agent/agent-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/agent/agent-configmap.yaml
@@ -10,4 +10,5 @@ data:
   K8S_API_URL: {{ .Values.agent.env.digiusher_k8s_api_url | quote }}
   LOG_LEVEL: {{ .Values.agent.env.log_level | quote }}
   PV_DIR: {{ .Values.agent.persistence.mountPath | quote }}
+  GOMEMLIMIT: {{ .Values.agent.goMemLimit | quote }}
 {{- end }}

--- a/charts/digiusher-k8s-agent/templates/agent/agent-statefulset.yaml
+++ b/charts/digiusher-k8s-agent/templates/agent/agent-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ include "digiusher-k8s-agent.image" (dict "image" .Values.agent.image "global" .Values.global) }}"
+          image: "{{ include "digiusher-k8s-agent.image" (dict "image" .Values.agent.image "global" .Values.global "appVersion" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   prometheus.yml: |
     # Per-job intervals are configured via vmagent.intervals in values.yaml.
-    # Defaults are 60s; tighten cadvisor specifically if you need to capture
+    # Defaults are 60s; tighten KSM (metadata) or cadvisor (usage) to capture
     # short-lived pods. See the values.yaml comment for the full rationale.
     global:
       scrape_interval: 60s
@@ -26,7 +26,7 @@ data:
         metric_relabel_configs:
           - source_labels: [__name__]
             action: keep
-            regex: "kube_daemonset_created|kube_daemonset_labels|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_available|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_ready|kube_daemonset_status_number_unavailable|kube_deployment_created|kube_deployment_labels|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_ready|kube_deployment_status_replicas_unavailable|kube_namespace_created|kube_namespace_labels|kube_namespace_status_phase|kube_node_created|kube_node_info|kube_node_labels|kube_node_role|kube_node_status_addresses|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_created|kube_pod_info|kube_pod_labels|kube_pod_start_time|kube_pod_status_phase|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_replicaset_created|kube_replicaset_labels|kube_replicaset_owner|kube_replicaset_status_ready_replicas|kube_replicaset_status_replicas|kube_resourcequota|kube_resourcequota_created|kube_resourcequota_labels|kube_service_created|kube_service_info|kube_service_labels|kube_service_spec_type|kube_cronjob_created|kube_cronjob_info|kube_cronjob_labels|kube_cronjob_next_schedule_time|kube_cronjob_status_active|kube_cronjob_status_last_schedule_time|kube_cronjob_status_last_successful_time|kube_job_created|kube_job_labels|kube_job_owner|kube_job_spec_completions|kube_job_spec_parallelism|kube_job_status_active|kube_job_status_completion_time|kube_job_status_failed|kube_job_status_start_time|kube_job_status_succeeded|kube_persistentvolume_capacity_bytes|kube_persistentvolume_created|kube_persistentvolume_info|kube_persistentvolume_labels|kube_persistentvolume_status_phase|kube_persistentvolume_volume_mode|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_created|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_condition|kube_persistentvolumeclaim_status_phase|kube_replicationcontroller_created|kube_replicationcontroller_owner|kube_replicationcontroller_status_available_replicas|kube_replicationcontroller_status_fully_labeled_replicas|kube_replicationcontroller_status_ready_replicas|kube_replicationcontroller_status_replicas|kube_statefulset_created|kube_statefulset_labels|kube_statefulset_persistentvolumeclaim_retention_policy|kube_statefulset_replicas|kube_statefulset_status_replicas|kube_statefulset_status_replicas_available|kube_statefulset_status_replicas_current|kube_statefulset_status_replicas_ready|kube_statefulset_status_replicas_updated|kube_storageclass_created|kube_storageclass_info|kube_storageclass_labels|kube_pod_spec_volumes_persistentvolumeclaims_info"
+            regex: "kube_daemonset_created|kube_daemonset_labels|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_available|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_ready|kube_daemonset_status_number_unavailable|kube_deployment_created|kube_deployment_labels|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_ready|kube_deployment_status_replicas_unavailable|kube_namespace_created|kube_namespace_labels|kube_namespace_status_phase|kube_node_created|kube_node_info|kube_node_labels|kube_node_role|kube_node_status_addresses|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_created|kube_pod_info|kube_pod_labels|kube_pod_start_time|kube_pod_status_phase|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_last_terminated_reason|kube_replicaset_created|kube_replicaset_labels|kube_replicaset_owner|kube_replicaset_status_ready_replicas|kube_replicaset_status_replicas|kube_resourcequota|kube_resourcequota_created|kube_resourcequota_labels|kube_service_created|kube_service_info|kube_service_labels|kube_service_spec_type|kube_cronjob_created|kube_cronjob_info|kube_cronjob_labels|kube_cronjob_next_schedule_time|kube_cronjob_status_active|kube_cronjob_status_last_schedule_time|kube_cronjob_status_last_successful_time|kube_job_created|kube_job_labels|kube_job_owner|kube_job_spec_completions|kube_job_spec_parallelism|kube_job_status_active|kube_job_status_completion_time|kube_job_status_failed|kube_job_status_start_time|kube_job_status_succeeded|kube_persistentvolume_capacity_bytes|kube_persistentvolume_created|kube_persistentvolume_info|kube_persistentvolume_labels|kube_persistentvolume_status_phase|kube_persistentvolume_volume_mode|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_created|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_condition|kube_persistentvolumeclaim_status_phase|kube_replicationcontroller_created|kube_replicationcontroller_owner|kube_replicationcontroller_status_available_replicas|kube_replicationcontroller_status_fully_labeled_replicas|kube_replicationcontroller_status_ready_replicas|kube_replicationcontroller_status_replicas|kube_statefulset_created|kube_statefulset_labels|kube_statefulset_persistentvolumeclaim_retention_policy|kube_statefulset_replicas|kube_statefulset_status_replicas|kube_statefulset_status_replicas_available|kube_statefulset_status_replicas_current|kube_statefulset_status_replicas_ready|kube_statefulset_status_replicas_updated|kube_storageclass_created|kube_storageclass_info|kube_storageclass_labels|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_horizontalpodautoscaler_info|kube_horizontalpodautoscaler_labels|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_horizontalpodautoscaler_status_condition|kube_poddisruptionbudget_created|kube_poddisruptionbudget_labels|kube_poddisruptionbudget_status_current_healthy|kube_poddisruptionbudget_status_desired_healthy|kube_poddisruptionbudget_status_pod_disruptions_allowed|kube_poddisruptionbudget_status_expected_pods|kube_poddisruptionbudget_status_total_pods"
 
       # cAdvisor: per-container CPU/memory/network from each kubelet.
       # Default 60s; tighten to ~20s for workloads with many short-lived pods
@@ -55,7 +55,7 @@ data:
             regex: "__name__|container|id|name|namespace|pod|interface"
           - source_labels: [__name__]
             action: keep
-            regex: "container_cpu_usage_seconds_total|container_memory_usage_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total"
+            regex: "container_cpu_usage_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_memory_usage_bytes|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_memory_swap|container_network_receive_bytes_total|container_network_transmit_bytes_total"
           # Network metrics: keep only pod-level (container=""), drop per-container
           - source_labels: [__name__, container]
             action: drop
@@ -65,6 +65,46 @@ data:
           - source_labels: [__name__, interface]
             action: drop
             regex: "container_network_.*_bytes_total;([^e]|e[^t]|et[^h]).*"
+
+      {{- if .Values.vmagent.dcgm.enabled }}
+      # GPU metrics from dcgm-exporter (e.g. the NVIDIA GPU operator's DaemonSet,
+      # typically port 9400). Off by default; assumes the exporter already runs
+      # in-cluster — no GPU workload is bundled. Namespace/selector/port are
+      # overridable via vmagent.dcgm in values.yaml.
+      - job_name: dcgm_scraper
+        scrape_interval: {{ .Values.vmagent.dcgm.interval | default "60s" }}
+        scrape_timeout: 10s
+        kubernetes_sd_configs:
+          - role: endpoints
+            {{- with .Values.vmagent.dcgm.namespace }}
+            namespaces:
+              names:
+                - {{ . }}
+            {{- end }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_{{ .Values.vmagent.dcgm.selectorLabelName }}]
+            regex: {{ .Values.vmagent.dcgm.selectorLabelValue | quote }}
+            action: keep
+          # Endpoints SD has no port-number meta-label; the only numeric-port
+          # source is __address__. Prometheus keep-regexes are fully anchored.
+          - source_labels: [__address__]
+            regex: ".*:{{ .Values.vmagent.dcgm.port }}"
+            action: keep
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            action: keep
+            regex: "DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_MEM_COPY_UTIL|DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION|DCGM_FI_DEV_POWER_USAGE|DCGM_FI_DEV_FB_USED|DCGM_FI_DEV_FB_FREE|DCGM_FI_PROF_SM_ACTIVE|DCGM_FI_PROF_PIPE_TENSOR_ACTIVE|DCGM_FI_PROF_DRAM_ACTIVE"
+          # dcgm-exporter labels the node as Hostname; promote it to `node`.
+          - source_labels: [Hostname]
+            target_label: node
+            action: replace
+          # Keep identity only: gpu/UUID/device/modelName ride the usage
+          # dimensions map; namespace/pod/container are present when the
+          # exporter's kubernetes mapping is enabled. The labelkeep also drops
+          # Hostname, instance, and job.
+          - action: labelkeep
+            regex: "__name__|namespace|pod|container|node|gpu|UUID|device|modelName|pci_bus_id"
+      {{- end }}
 
       # Kubelet /metrics for PVC volume stats. Storage capacity changes
       # slowly; 60s is plenty.
@@ -91,4 +131,45 @@ data:
             regex: "kubelet_volume_stats_used_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_available_bytes"
           - action: labelkeep
             regex: "__name__|namespace|persistentvolumeclaim|node|instance|job"
+
+      {{- if .Values.vmagent.nodeExporter.enabled }}
+      # Node-level utilization from node-exporter, for node-consolidation /
+      # bin-packing analysis (the gap between node allocatable and actual node
+      # usage is stranded spend that container sums under-count by the
+      # system/kubelet/OS overhead). Off by default; assumes node-exporter
+      # already runs in-cluster — this chart deploys no node-exporter. A
+      # curated keep-list (CPU/memory/filesystem/disk/network/load) keeps the
+      # per-node series count well below node-exporter's ~270-series default.
+      # Namespace/selector/port are overridable via vmagent.nodeExporter.
+      - job_name: node_exporter_scraper
+        scrape_interval: {{ .Values.vmagent.nodeExporter.interval | default "60s" }}
+        scrape_timeout: 10s
+        kubernetes_sd_configs:
+          - role: endpoints
+            {{- with .Values.vmagent.nodeExporter.namespace }}
+            namespaces:
+              names:
+                - {{ . }}
+            {{- end }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_{{ .Values.vmagent.nodeExporter.selectorLabelName }}]
+            regex: {{ .Values.vmagent.nodeExporter.selectorLabelValue | quote }}
+            action: keep
+          - source_labels: [__address__]
+            regex: ".*:{{ .Values.vmagent.nodeExporter.port }}"
+            action: keep
+          # node-exporter has no `node` label; attribute each series to the
+          # node its DaemonSet pod runs on.
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: node
+            action: replace
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            action: keep
+            regex: "node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_memory_Active_bytes|node_memory_Inactive_bytes|node_filesystem_size_bytes|node_filesystem_avail_bytes|node_filesystem_free_bytes|node_disk_read_bytes_total|node_disk_written_bytes_total|node_network_receive_bytes_total|node_network_transmit_bytes_total|node_load1"
+          # Keep node + the few intra-metric breakdown labels; drop instance,
+          # job, pod, endpoint, etc.
+          - action: labelkeep
+            regex: "__name__|node|cpu|mode|device|mountpoint|fstype"
+      {{- end }}
 {{- end }}

--- a/charts/digiusher-k8s-agent/templates/vmagent/vmagent-deployment.yaml
+++ b/charts/digiusher-k8s-agent/templates/vmagent/vmagent-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - -remoteWrite.forcePromProto=true
             - -remoteWrite.tmpDataPath=/vmagent-data
             - -remoteWrite.maxDiskUsagePerURL={{ .Values.vmagent.maxDiskUsagePerURL | default "5GB" }}
+            {{- with .Values.vmagent.memoryAllowedBytes }}
+            # Soft memory cap; bounds vmagent's startup/peak heap. See values.yaml.
+            - -memory.allowedBytes={{ . }}
+            {{- end }}
             - -httpListenAddr=:8429
             - -loggerFormat=json
           ports:

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -202,6 +202,14 @@ vmagent:
   # vmagent buffers samples here when the agent is unreachable; size this to
   # cover the longest acceptable outage window.
   maxDiskUsagePerURL: "20GB"
+  # Soft cap on the memory vmagent allows itself (Go's -memory.allowedBytes).
+  # vmagent transiently allocates a large heap at startup and frees it back to
+  # the OS afterward; this paces that so peak/startup memory stays bounded
+  # instead of briefly spiking well above steady state. Size it ABOVE your
+  # steady-state vmagent usage with headroom — set too low it raises CPU and
+  # can cause sample drops. Leave "" to use vmagent's own default (a fraction
+  # of the container/host memory).
+  memoryAllowedBytes: "1GB"
   persistence:
     enabled: true
     size: 30Gi
@@ -248,6 +256,15 @@ kube-state-metrics:
     requests:
       cpu: 50m
       memory: 128Mi
+  # Soft Go heap ceiling for kube-state-metrics. KSM allocates a large heap
+  # during its initial LIST of all cluster objects on startup and settles
+  # afterward; GOMEMLIMIT paces GC so that startup spike stays bounded instead
+  # of briefly peaking well above steady state. Size it ABOVE your steady-state
+  # KSM usage (which grows with object count) with headroom — set too low it
+  # drives GC CPU up. Remove this entry to leave KSM's heap uncapped.
+  env:
+    - name: GOMEMLIMIT
+      value: "1GiB"
   extraArgs:
     - "--metric-labels-allowlist=pods=[*],nodes=[*],services=[selector],resourcequotas=[*],jobs=[*],namespaces=[*],endpoints=[*]"
     # Annotation-based cost allocation. KSM emits no annotations by default;

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -40,10 +40,10 @@ agent:
     repository: ghcr.io/digiusher/digiusher-k8s-agent
     devRepository: ghcr.io/digiusher/digiusher-k8s-agent-dev
     pullPolicy: IfNotPresent
-    # Pin to a published SemVer tag in production so installs are reproducible
-    # across image pushes. The default below is a placeholder; override per
-    # release.
-    tag: "latest"
+    # Leave empty to ship the chart's appVersion (the released image version,
+    # single-sourced in Chart.yaml) — the reproducible default. Override only
+    # to run a specific build, e.g. --set agent.image.tag=<version-or-sha>.
+    tag: ""
     # Required when global.useDevImages=true. The *-dev package has no `latest`
     # tag, so this must be set to a SHA via --set agent.image.devTag=<sha>.
     devTag: ""

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -28,9 +28,10 @@ serviceAccount:
   name: ""
 
 #########################################
-# Agent — the collapsed Go binary that receives Prometheus remote_write from
-# vmagent, aggregates in memory, snapshots to PV for crash recovery, builds
-# parquet at window close, and uploads via pre-signed S3 URL.
+# Agent — the Go binary that receives Prometheus remote_write from vmagent,
+# streams raw samples straight to native parquet on disk (flat memory,
+# no in-memory window buffer), and uploads completed files via a pre-signed S3
+# URL. The PV holds pending/in-flight parquet for durability across restarts.
 #########################################
 agent:
   enabled: true
@@ -59,25 +60,32 @@ agent:
     size: 20Gi
     storageClassName: ""
     mountPath: /var/lib/digiusher-agent/pending
-  # Memory scales with active series count (~750 bytes/series).
-  # 1Gi covers clusters up to ~1000 nodes.
-  # Increase to 2Gi for larger clusters or if OOMKilled events appear.
+  # Memory is a low, flat target. The agent streams rows to disk with a bounded
+  # row-group buffer and paces its Go heap with GOMEMLIMIT (see goMemLimit
+  # below), so resident memory stays flat and does not scale with series
+  # cardinality or cluster size. The limit sits above the GOMEMLIMIT target with
+  # headroom for the runtime and reclaimable page cache.
   resources:
     requests:
       cpu: 200m
-      memory: 256Mi
+      memory: 128Mi
     limits:
       cpu: 2000m
-      memory: 1Gi
+      memory: 640Mi
+  # Soft Go heap ceiling. Paces GC to keep resident memory bounded well under
+  # the limit above, giving the container a flat, predictable footprint instead
+  # of one that grows with load. Keep it below limits.memory with headroom. Uses
+  # Go's size format (MiB/GiB), which differs from the Kubernetes quantity above.
+  goMemLimit: "460MiB"
   env:
     # Required — provided by the DigiUsher team. Secret only renders when this
     # is non-empty; the agent fails fast on startup if the env var is missing.
     digiusher_k8s_api_token: ""
     digiusher_k8s_api_url: "https://app.digiusher.com/api/v3"
     log_level: "info"
-  # Raw `env:` entries for advanced overrides (e.g., SNAPSHOT_TICK_SECONDS,
-  # UPLOAD_TICK_SECONDS, MAX_REQUEST_BYTES). The agent's built-in defaults
-  # are correct for this chart's design ceilings; override only when needed.
+  # Raw `env:` entries for advanced overrides (e.g., UPLOAD_TICK_SECONDS,
+  # MAX_REQUEST_BYTES). The agent's built-in defaults are correct for this
+  # chart's design ceilings; override only when needed.
   extraEnv: []
   # Distroless `nonroot` (UID 65532).
   podSecurityContext:
@@ -94,12 +102,15 @@ agent:
     allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 65532
+  # Readiness now flips after a fast staging-dir scan (no snapshot load), so the
+  # startup budget no longer needs to cover a slow recovery: 12 × 10s = 120s,
+  # ample headroom for image pull + PVC attach.
   startupProbe:
     httpGet:
       path: /readyz
       port: http
     periodSeconds: 10
-    failureThreshold: 18
+    failureThreshold: 12
   livenessProbe:
     httpGet:
       path: /healthz
@@ -147,12 +158,46 @@ vmagent:
   # vmagent's own footprint is series-driven, not scrape-rate-driven, so a
   # lower cAdvisor interval barely moves the scraper's memory or CPU.
   #
-  # KSM and kubelet rarely benefit from sub-60s scraping; the API server is
-  # the bottleneck for KSM, and storage capacity changes slowly.
+  # Tighten KSM (e.g. ~20–30s) to catch short-lived pods/jobs before they
+  # vanish — the agent's change-detection keeps downstream volume bounded, so a
+  # faster KSM scrape costs API-server read load, not downstream samples.
+  # Validate kube-apiserver headroom before going low. kubelet stays at 60s;
+  # storage capacity changes slowly.
   intervals:
     ksm: "60s"
     cadvisor: "60s"
     kubelet: "60s"
+  # GPU metrics via dcgm-exporter, for GPU cost/utilization. ON by default:
+  # vmagent discovers the dcgm-exporter Service endpoints (e.g. the NVIDIA GPU
+  # operator's, in the gpu-operator namespace) and scrapes a targeted metric
+  # set. When no dcgm-exporter is present the scrape job finds no targets — a
+  # harmless no-op — so non-GPU clusters pay nothing and GPU clusters start
+  # collecting the moment the exporter exists. Set false to opt out.
+  dcgm:
+    enabled: true
+    namespace: "gpu-operator"            # set to "" to scan all namespaces
+    # Service label selector. selectorLabelName must be the underscore-sanitized
+    # label key as vmagent exposes it (dots/slashes become underscores).
+    selectorLabelName: "app_kubernetes_io_name"
+    selectorLabelValue: "dcgm-exporter"
+    port: "9400"
+    interval: "60s"
+  # Node-level utilization via node-exporter, for node-consolidation analysis.
+  # ON by default: vmagent discovers the node-exporter Service endpoints and
+  # scrapes a curated node CPU/memory/filesystem/disk/network/load set. When no
+  # node-exporter Service is present the scrape job simply finds no targets — a
+  # harmless no-op — so leaving it on costs nothing on clusters without one and
+  # starts collecting the moment one exists (no chart change needed). Set false
+  # to opt out of scraping an existing node-exporter.
+  nodeExporter:
+    enabled: true
+    namespace: ""                        # "" scans all namespaces (location varies by install)
+    # Service label selector. selectorLabelName must be the underscore-sanitized
+    # label key as vmagent exposes it (dots/slashes become underscores).
+    selectorLabelName: "app_kubernetes_io_name"
+    selectorLabelValue: "node-exporter"
+    port: "9100"
+    interval: "60s"
   # Disk usage cap for vmagent's remote_write retry queue per remote_write URL.
   # vmagent buffers samples here when the agent is unreachable; size this to
   # cover the longest acceptable outage window.
@@ -161,13 +206,15 @@ vmagent:
     enabled: true
     size: 30Gi
     storageClassName: ""
+  # Memory request only; the limit is left unset — set one sized to your
+  # cluster if you want a hard ceiling.
+  # vmagent's footprint is series-driven, bounded by the keep-list above.
   resources:
     requests:
       cpu: 200m
       memory: 256Mi
     limits:
       cpu: 500m
-      memory: 512Mi
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -194,8 +241,22 @@ vmagent:
 # Kube State Metrics configurations
 #########################################
 kube-state-metrics:
+  # Memory request only; the limit is left unset — set one sized to your
+  # cluster if you want a hard ceiling.
+  # KSM memory scales with cluster object count.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
   extraArgs:
     - "--metric-labels-allowlist=pods=[*],nodes=[*],services=[selector],resourcequotas=[*],jobs=[*],namespaces=[*],endpoints=[*]"
+    # Annotation-based cost allocation. KSM emits no annotations by default;
+    # this surfaces the keys your org tags with for chargeback. Set the keys to
+    # match your conventions (cost-center / team / owner, etc.). Do NOT use
+    # [*] — it pulls in huge annotations like
+    # kubectl.kubernetes.io/last-applied-configuration and explodes cardinality.
+    # Overriding extraArgs replaces the whole list, so keep the line above too.
+    - "--metric-annotations-allowlist=pods=[team,cost-center,owner],namespaces=[team,cost-center,owner]"
   podLabels:
     owner: digiusher-k8s
     component: external


### PR DESCRIPTION
## Summary

Chart 0.4.0. Two themes: pin the agent's memory footprint, and broaden the collected metric surface.

### Agent memory
- Set `GOMEMLIMIT` (`agent.goMemLimit`, default `460MiB`) and a `640Mi` memory limit, so resident memory stays flat and bounded regardless of cluster size instead of growing with load. The limit sits above the GOMEMLIMIT target with headroom.
- Lower the startup probe failure budget to match faster readiness.

### Collection (vmagent)
- More KSM series: pod restarts / last-terminated reason, HPA, PodDisruptionBudget.
- More cAdvisor series: CPU throttling, memory working-set / rss / cache / swap.
- New opt-in scrape jobs for `dcgm-exporter` (GPU) and `node-exporter`, discovered via existing in-cluster Services. Harmless no-ops when those exporters aren't present.
- KSM annotation-based cost-allocation knobs.

Draft pending validation.