### PR TITLE
chart: drop kube-state-metrics, agent synthesizes metadata in-process (0.5.0)

### DIFF
--- a/charts/digiusher-k8s-agent/Chart.lock
+++ b/charts/digiusher-k8s-agent/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: kube-state-metrics
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.1
-digest: sha256:0e9cdbb7fbdb44b2e36fdd7b21f06cf8e5e8a8054a7cb4128db980af2abfb28d
-generated: "2026-05-12T14:27:19.229561062+02:00"

--- a/charts/digiusher-k8s-agent/Chart.yaml
+++ b/charts/digiusher-k8s-agent/Chart.yaml
@@ -15,16 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
-
-# Required dependencies
-dependencies:
-  - name: kube-state-metrics
-    version: "5.30.1"
-    repository: https://prometheus-community.github.io/helm-charts
+appVersion: "1.2.0"

--- a/charts/digiusher-k8s-agent/README.md
+++ b/charts/digiusher-k8s-agent/README.md
@@ -1,0 +1,152 @@
+# digiusher-k8s-agent
+
+A lightweight Kubernetes collection agent for [DigiUsher](https://www.digiusher.com).
+It scrapes per-node usage metrics, synthesizes object metadata in-process, and streams
+compact columnar files to DigiUsher for cost and usage analysis — with **no in-cluster
+time-series database** to run, scale, or pay for.
+
+## What it deploys
+
+| Component | What it does |
+| --- | --- |
+| **agent** | A `StatefulSet` (one replica). Receives Prometheus `remote_write` from vmagent, watches the Kubernetes API via informers to synthesize `kube_*` object metadata in-process, streams raw samples to native parquet on a PersistentVolume, and uploads completed files to DigiUsher via a pre-signed URL. The PV holds in-flight parquet so nothing is lost across restarts. |
+| **vmagent** | A `Deployment` (one replica). Scrapes every kubelet's cAdvisor + `/metrics` endpoints (plus optional dcgm-exporter and node-exporter) via Kubernetes service discovery, keeps a curated metric set, and `remote_write`s to the agent. |
+
+There is no kube-state-metrics dependency — the agent synthesizes that metadata itself.
+
+## Prerequisites
+
+- A Kubernetes cluster and Helm 3.
+- A DigiUsher API token (provided by the DigiUsher team).
+- Permission to create the agent's `ClusterRole`/`ClusterRoleBinding` (get/list/watch on the
+  watched kinds), or have an admin pre-create them and set `agent.rbac.create=false`.
+
+## Install
+
+```console
+helm repo add digiusher https://digiusher.github.io/helm-charts
+helm repo update
+
+helm install digiusher-k8s-agent digiusher/digiusher-k8s-agent \
+  --namespace digiusher-k8s --create-namespace \
+  --set agent.env.digiusher_k8s_api_token=<API_TOKEN>
+```
+
+To uninstall:
+
+```console
+helm uninstall digiusher-k8s-agent --namespace digiusher-k8s
+```
+
+## Sizing
+
+The two components scale differently, so they tune differently:
+
+- **agent — flat.** It streams samples straight to disk and paces its Go heap with
+  `agent.goMemLimit`, so its memory does **not** grow with cluster size or series cardinality.
+  The default fits clusters of any size as-is; you do not raise it as you grow.
+- **vmagent — series-driven.** Its footprint grows with the number of active series it scrapes
+  (≈ nodes × pods × kept metrics). On large / high-cardinality clusters this is the component to
+  size up: raise `vmagent.memoryAllowedBytes` (with headroom above steady state) and optionally
+  set an explicit `vmagent.resources.limits.memory`.
+
+Rule of thumb: if memory pressure appears as you scale, it is vmagent — the agent stays flat.
+The chart **defaults carry a large cluster (well into the thousands of nodes) comfortably**; you
+generally don't change them. Tune only at the edges:
+
+| Situation | What to set |
+| --- | --- |
+| Typical clusters (up to a few thousand nodes) | Leave the defaults — agent stays flat; `vmagent.memoryAllowedBytes: 1GB` has ample headroom. |
+| Small clusters reclaiming overhead | Optionally lower `agent.resources.limits.memory` + `agent.goMemLimit` together (keep GOMEMLIMIT below the limit). |
+| Very large / high-cardinality clusters | Raise `vmagent.memoryAllowedBytes` above steady-state usage and set an explicit `vmagent.resources.limits.memory`. The agent's defaults still hold. |
+
+## Configuration
+
+Set values with `--set key=value` or a `-f values.yaml` overrides file. The most common change
+is the required API token (`agent.env.digiusher_k8s_api_token`).
+
+### Global
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `global.useDevImages` | Pull the private `*-dev` images instead of the public prod ones (requires `imagePullSecrets` and per-service `image.devTag`). | `false` |
+| `global.imagePullSecrets` | Image-pull secrets for private registries. | `[]` |
+
+### Service account
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `serviceAccount.create` | Create a ServiceAccount for the agent. | `true` |
+| `serviceAccount.automount` | Auto-mount the ServiceAccount token. | `true` |
+| `serviceAccount.name` | Name to use; empty derives from the release name. | `""` |
+| `serviceAccount.annotations` | Annotations for the ServiceAccount. | `{}` |
+
+### Agent
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `agent.enabled` | Deploy the agent. | `true` |
+| `agent.image.repository` | Agent image repository. | `ghcr.io/digiusher/digiusher-k8s-agent` |
+| `agent.image.tag` | Image tag; empty ships the chart's `appVersion`. | `""` |
+| `agent.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `agent.env.digiusher_k8s_api_token` | **Required.** DigiUsher API token. | `""` |
+| `agent.env.digiusher_k8s_api_url` | DigiUsher ingestion endpoint. | `https://app.digiusher.com/api/v3` |
+| `agent.env.log_level` | Log level. | `info` |
+| `agent.extraEnv` | Extra raw `env:` entries for advanced overrides. | `[]` |
+| `agent.resources` | Agent CPU/memory requests and limits. Memory is flat — see Sizing. | requests `200m`/`128Mi`, limits `2000m`/`1536Mi` |
+| `agent.goMemLimit` | Soft Go heap ceiling (Go size format); keep below `resources.limits.memory`. | `1280MiB` |
+| `agent.rbac.create` | Create the agent ClusterRole/ClusterRoleBinding. Set `false` to manage out of band. | `true` |
+| `agent.service.port` | Agent metrics/ingest port. | `8111` |
+| `agent.persistence.enabled` | Use a PersistentVolume for in-flight parquet. | `true` |
+| `agent.persistence.size` | PVC size; scale up for higher cardinality or longer outage tolerance. | `20Gi` |
+| `agent.persistence.storageClassName` | PVC storage class; empty uses the cluster default. | `""` |
+
+#### Agent metadata (informers)
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `agent.informers.emitIntervalSeconds` | Seconds between metadata snapshots (clamped 15–300). | `60` |
+| `agent.informers.annotationKeys` | Comma-separated annotation keys to collect for cost allocation. Match your chargeback tags; avoid high-cardinality keys. | `team,cost-center,owner` |
+| `agent.informers.disabledKinds` | Comma-separated resource kinds to stop watching (plural lowercase); empty watches all. | `""` |
+| `agent.informers.enableParityExport` | Export the KSM-parity debug endpoint (diagnostics only). | `false` |
+
+### vmagent
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `vmagent.enabled` | Deploy vmagent. | `true` |
+| `vmagent.image.repository` | vmagent image repository. | `victoriametrics/vmagent` |
+| `vmagent.image.tag` | vmagent image tag. | `v1.143.0` |
+| `vmagent.intervals.cadvisor` | cAdvisor scrape interval; tighten (e.g. `20s`) for clusters with many short-lived pods. | `60s` |
+| `vmagent.intervals.kubelet` | Kubelet scrape interval. | `60s` |
+| `vmagent.memoryAllowedBytes` | Soft cap on vmagent's memory (`-memory.allowedBytes`); size above steady state with headroom. The main lever on large clusters. | `1GB` |
+| `vmagent.maxDiskUsagePerURL` | Disk cap for vmagent's remote_write retry queue (outage buffer). | `20GB` |
+| `vmagent.resources` | vmagent CPU/memory requests; memory limit is unset by default — set one to cap hard. | requests `200m`/`256Mi`, limits `500m` cpu |
+| `vmagent.persistence.enabled` | Use a PersistentVolume for the remote_write queue. | `true` |
+| `vmagent.persistence.size` | vmagent queue PVC size. | `30Gi` |
+
+#### Optional exporters (auto-detected)
+
+Both are **on by default** and are a harmless no-op when the matching exporter isn't present — the
+scrape job simply finds no targets, so non-GPU/non-node-exporter clusters pay nothing and
+collection starts the moment an exporter appears (no chart change needed).
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `vmagent.dcgm.enabled` | Scrape dcgm-exporter for GPU cost/utilization. | `true` |
+| `vmagent.dcgm.namespace` | Namespace to discover dcgm-exporter in; `""` scans all. | `gpu-operator` |
+| `vmagent.dcgm.selectorLabelName` / `selectorLabelValue` | Service label selector for dcgm-exporter (underscore-sanitized key). | `app_kubernetes_io_name` / `dcgm-exporter` |
+| `vmagent.dcgm.port` / `interval` | dcgm-exporter port and scrape interval. | `9400` / `60s` |
+| `vmagent.nodeExporter.enabled` | Scrape node-exporter for node-consolidation analysis. | `true` |
+| `vmagent.nodeExporter.namespace` | Namespace to discover node-exporter in; `""` scans all. | `""` |
+| `vmagent.nodeExporter.selectorLabelName` / `selectorLabelValue` | Service label selector for node-exporter. | `app_kubernetes_io_name` / `node-exporter` |
+| `vmagent.nodeExporter.port` / `interval` | node-exporter port and scrape interval. | `9100` / `60s` |
+
+### Scheduling & security (both components)
+
+`nodeSelector`, `tolerations`, `affinity`, `podAnnotations`, `podSecurityContext`, `securityContext`,
+and the agent's `startupProbe`/`livenessProbe`/`readinessProbe` follow standard Helm conventions and
+can be overridden per component (`agent.*` / `vmagent.*`). Both components ship with a
+`digiusher-k8s` `NoSchedule` toleration by default; clear it if you don't taint nodes for the agent.
+
+See [`values.yaml`](./values.yaml) for the complete set and inline rationale.

--- a/charts/digiusher-k8s-agent/templates/_helpers.tpl
+++ b/charts/digiusher-k8s-agent/templates/_helpers.tpl
@@ -69,15 +69,6 @@ two installs in one namespace don't collide.
 {{- end }}
 
 {{/*
-KSM service name. Mirrors the kube-state-metrics subchart's own fullname
-output for any release name not containing "kube-state-metrics" and where
-KSM has no fullnameOverride — both reasonable assumptions for this chart.
-*/}}
-{{- define "digiusher-k8s-agent.ksm.fullname" -}}
-{{- printf "%s-kube-state-metrics" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end }}
-
-{{/*
 Per-component selector labels. Each Deployment selects only its own pods.
 */}}
 {{- define "digiusher-k8s-agent.agent.selectorLabels" -}}

--- a/charts/digiusher-k8s-agent/templates/agent/agent-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/agent/agent-configmap.yaml
@@ -11,4 +11,13 @@ data:
   LOG_LEVEL: {{ .Values.agent.env.log_level | quote }}
   PV_DIR: {{ .Values.agent.persistence.mountPath | quote }}
   GOMEMLIMIT: {{ .Values.agent.goMemLimit | quote }}
+  # In-process metadata (informers). The agent watches the Kubernetes API and
+  # synthesizes the kube_* surface itself; see agent.informers in values.yaml.
+  EMIT_INTERVAL_SECONDS: {{ .Values.agent.informers.emitIntervalSeconds | quote }}
+  INFORMERS_ANNOTATION_KEYS: {{ .Values.agent.informers.annotationKeys | quote }}
+  KUBEMETA_DISABLED_KINDS: {{ .Values.agent.informers.disabledKinds | quote }}
+  ENABLE_PARITY_EXPORT: {{ .Values.agent.informers.enableParityExport | quote }}
+  {{- with .Values.agent.informers.kubeconfig }}
+  KUBEMETA_KUBECONFIG: {{ . | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/digiusher-k8s-agent/templates/agent/agent-rbac.yaml
+++ b/charts/digiusher-k8s-agent/templates/agent/agent-rbac.yaml
@@ -1,7 +1,11 @@
-{{- if .Values.agent.enabled }}
+{{- if and .Values.agent.enabled .Values.agent.rbac.create }}
 # The agent watches the Kubernetes API via informers and synthesizes object
 # metadata in-process. This grants get/list/watch on exactly the kinds it
-# watches, bound to the agent ServiceAccount.
+# watches, bound to the agent ServiceAccount. vmagent shares that
+# ServiceAccount, so the endpoints permission below also covers its
+# endpoint-role service discovery (dcgm-exporter / node-exporter).
+# Set agent.rbac.create=false to manage the ClusterRole/Binding out of band
+# (e.g. restricted clusters where namespace admins can't create cluster roles).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,6 +21,8 @@ rules:
       - namespaces
       - replicationcontrollers
       - services
+      # For vmagent's endpoint-role service discovery (shared ServiceAccount).
+      - endpoints
       - resourcequotas
       - persistentvolumes
       - persistentvolumeclaims

--- a/charts/digiusher-k8s-agent/templates/agent/agent-rbac.yaml
+++ b/charts/digiusher-k8s-agent/templates/agent/agent-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.agent.enabled }}
+# The agent watches the Kubernetes API via informers and synthesizes object
+# metadata in-process. This grants get/list/watch on exactly the kinds it
+# watches, bound to the agent ServiceAccount.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "digiusher-k8s-agent.agent.fullname" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - replicationcontrollers
+      - services
+      - resourcequotas
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: [deployments, daemonsets, replicasets, statefulsets]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: [jobs, cronjobs]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: [horizontalpodautoscalers]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: [poddisruptionbudgets]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: [storageclasses]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "digiusher-k8s-agent.agent.fullname" . }}
+  labels:
+    {{- include "digiusher-k8s-agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "digiusher-k8s-agent.agent.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "digiusher-k8s-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
@@ -9,25 +9,13 @@ metadata:
 data:
   prometheus.yml: |
     # Per-job intervals are configured via vmagent.intervals in values.yaml.
-    # Defaults are 60s; tighten KSM (metadata) or cadvisor (usage) to capture
-    # short-lived pods. See the values.yaml comment for the full rationale.
+    # Defaults are 60s; tighten cadvisor to capture short-lived pods. See the
+    # values.yaml comment for the full rationale.
     global:
       scrape_interval: 60s
       scrape_timeout: 10s
 
     scrape_configs:
-      # KSM cluster metadata — pod/workload/PVC objects via the API server.
-      - job_name: ksm_scraper
-        scrape_interval: {{ .Values.vmagent.intervals.ksm | default "60s" }}
-        scrape_timeout: 10s
-        static_configs:
-          - targets:
-              - {{ include "digiusher-k8s-agent.ksm.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080
-        metric_relabel_configs:
-          - source_labels: [__name__]
-            action: keep
-            regex: "kube_daemonset_created|kube_daemonset_labels|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_available|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_ready|kube_daemonset_status_number_unavailable|kube_deployment_created|kube_deployment_labels|kube_deployment_status_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_ready|kube_deployment_status_replicas_unavailable|kube_namespace_created|kube_namespace_labels|kube_namespace_status_phase|kube_node_created|kube_node_info|kube_node_labels|kube_node_role|kube_node_status_addresses|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_created|kube_pod_info|kube_pod_labels|kube_pod_start_time|kube_pod_status_phase|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_last_terminated_reason|kube_replicaset_created|kube_replicaset_labels|kube_replicaset_owner|kube_replicaset_status_ready_replicas|kube_replicaset_status_replicas|kube_resourcequota|kube_resourcequota_created|kube_resourcequota_labels|kube_service_created|kube_service_info|kube_service_labels|kube_service_spec_type|kube_cronjob_created|kube_cronjob_info|kube_cronjob_labels|kube_cronjob_next_schedule_time|kube_cronjob_status_active|kube_cronjob_status_last_schedule_time|kube_cronjob_status_last_successful_time|kube_job_created|kube_job_labels|kube_job_owner|kube_job_spec_completions|kube_job_spec_parallelism|kube_job_status_active|kube_job_status_completion_time|kube_job_status_failed|kube_job_status_start_time|kube_job_status_succeeded|kube_persistentvolume_capacity_bytes|kube_persistentvolume_created|kube_persistentvolume_info|kube_persistentvolume_labels|kube_persistentvolume_status_phase|kube_persistentvolume_volume_mode|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_created|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_condition|kube_persistentvolumeclaim_status_phase|kube_replicationcontroller_created|kube_replicationcontroller_owner|kube_replicationcontroller_status_available_replicas|kube_replicationcontroller_status_fully_labeled_replicas|kube_replicationcontroller_status_ready_replicas|kube_replicationcontroller_status_replicas|kube_statefulset_created|kube_statefulset_labels|kube_statefulset_persistentvolumeclaim_retention_policy|kube_statefulset_replicas|kube_statefulset_status_replicas|kube_statefulset_status_replicas_available|kube_statefulset_status_replicas_current|kube_statefulset_status_replicas_ready|kube_statefulset_status_replicas_updated|kube_storageclass_created|kube_storageclass_info|kube_storageclass_labels|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_horizontalpodautoscaler_info|kube_horizontalpodautoscaler_labels|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_horizontalpodautoscaler_status_condition|kube_poddisruptionbudget_created|kube_poddisruptionbudget_labels|kube_poddisruptionbudget_status_current_healthy|kube_poddisruptionbudget_status_desired_healthy|kube_poddisruptionbudget_status_pod_disruptions_allowed|kube_poddisruptionbudget_status_expected_pods|kube_poddisruptionbudget_status_total_pods"
-
       # cAdvisor: per-container CPU/memory/network from each kubelet.
       # Default 60s; tighten to ~20s for workloads with many short-lived pods
       # (capture probability for a 15s pod goes from ~25% at 60s to ~75% at 20s).
@@ -49,8 +37,8 @@ data:
             target_label: __address__
         metric_relabel_configs:
           # No `node` label: container metrics are attributed to nodes on the
-          # backend via a pod→node join on kube_pod_info (kept by KSM), so node
-          # is intentionally dropped here to keep cardinality down.
+          # backend via a pod→node join on kube_pod_info (synthesized in-process
+          # by the agent), so node is intentionally dropped here for cardinality.
           - action: labelkeep
             regex: "__name__|container|id|name|namespace|pod|interface"
           - source_labels: [__name__]

--- a/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
+++ b/charts/digiusher-k8s-agent/templates/vmagent/vmagent-configmap.yaml
@@ -39,11 +39,13 @@ data:
           # No `node` label: container metrics are attributed to nodes on the
           # backend via a pod→node join on kube_pod_info (synthesized in-process
           # by the agent), so node is intentionally dropped here for cardinality.
+          # `device` is kept for the per-device container_fs_* series below; it is
+          # absent on the cpu/memory/network families so it costs nothing there.
           - action: labelkeep
-            regex: "__name__|container|id|name|namespace|pod|interface"
+            regex: "__name__|container|id|name|namespace|pod|interface|device"
           - source_labels: [__name__]
             action: keep
-            regex: "container_cpu_usage_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_memory_usage_bytes|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_memory_swap|container_network_receive_bytes_total|container_network_transmit_bytes_total"
+            regex: "container_cpu_usage_seconds_total|container_cpu_cfs_throttled_periods_total|container_cpu_cfs_periods_total|container_memory_usage_bytes|container_memory_working_set_bytes|container_memory_rss|container_memory_cache|container_memory_swap|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_fs_usage_bytes|container_fs_limit_bytes"
           # Network metrics: keep only pod-level (container=""), drop per-container
           - source_labels: [__name__, container]
             action: drop
@@ -154,7 +156,7 @@ data:
         metric_relabel_configs:
           - source_labels: [__name__]
             action: keep
-            regex: "node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_memory_Active_bytes|node_memory_Inactive_bytes|node_filesystem_size_bytes|node_filesystem_avail_bytes|node_filesystem_free_bytes|node_disk_read_bytes_total|node_disk_written_bytes_total|node_network_receive_bytes_total|node_network_transmit_bytes_total|node_load1"
+            regex: "node_cpu_seconds_total|node_memory_MemTotal_bytes|node_memory_MemAvailable_bytes|node_memory_MemFree_bytes|node_memory_Cached_bytes|node_memory_Buffers_bytes|node_memory_Active_bytes|node_memory_Inactive_bytes|node_filesystem_size_bytes|node_filesystem_avail_bytes|node_filesystem_free_bytes|node_disk_read_bytes_total|node_disk_written_bytes_total|node_disk_io_time_seconds_total|node_disk_reads_completed_total|node_disk_writes_completed_total|node_network_receive_bytes_total|node_network_transmit_bytes_total|node_load1"
           # Keep node + the few intra-metric breakdown labels; drop instance,
           # job, pod, endpoint, etc.
           - action: labelkeep

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -17,6 +17,32 @@ global:
   imagePullSecrets: []
 
 #########################################
+# Resource sizing across cluster sizes
+#
+# The two components scale differently, so they tune differently:
+#
+#   Agent — FLAT. It streams samples straight to disk and paces its Go heap
+#     with GOMEMLIMIT, so its memory does not grow with cluster size or series
+#     cardinality. The default (agent.resources + agent.goMemLimit) is intended
+#     to fit clusters of any size as-is — you do NOT raise it as you grow. On
+#     small clusters you may lower agent.resources.limits.memory and
+#     agent.goMemLimit together (keep GOMEMLIMIT below the limit with headroom)
+#     to reclaim a little overhead, but it is rarely worth it.
+#
+#   vmagent — SERIES-DRIVEN. Its footprint grows with the number of active
+#     series it scrapes (roughly nodes x pods x kept metrics), not with scrape
+#     rate. The defaults (vmagent.memoryAllowedBytes, vmagent.resources) carry a
+#     generous cluster comfortably. For large / high-cardinality clusters this
+#     is the component to size up: raise vmagent.memoryAllowedBytes with headroom
+#     above steady-state usage and set an explicit vmagent.resources.limits.memory
+#     (left unset by default) if you want a hard ceiling. On small clusters the
+#     defaults are already ample.
+#
+# Rule of thumb: if memory pressure appears as you scale, it is vmagent — the
+# agent stays flat. Per-component tuning notes live with each stanza below.
+#########################################
+
+#########################################
 # Service Account
 #########################################
 serviceAccount:
@@ -64,7 +90,8 @@ agent:
   # row-group buffer and paces its Go heap with GOMEMLIMIT (see goMemLimit
   # below), so resident memory stays flat and does not scale with series
   # cardinality or cluster size. The limit sits above the GOMEMLIMIT target with
-  # headroom for the runtime and reclaimable page cache.
+  # headroom for the runtime and reclaimable page cache. This default fits any
+  # cluster size as-is — see "Resource sizing across cluster sizes" up top.
   resources:
     requests:
       cpu: 200m
@@ -238,7 +265,10 @@ vmagent:
     storageClassName: ""
   # Memory request only; the limit is left unset — set one sized to your
   # cluster if you want a hard ceiling.
-  # vmagent's footprint is series-driven, bounded by the keep-list above.
+  # vmagent's footprint is series-driven, bounded by the keep-list above. This
+  # is the component to size up on large / high-cardinality clusters (raise
+  # memoryAllowedBytes, optionally set a limit here) — see "Resource sizing
+  # across cluster sizes" up top.
   resources:
     requests:
       cpu: 200m

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -77,6 +77,12 @@ agent:
   # of one that grows with load. Keep it below limits.memory with headroom. Uses
   # Go's size format (MiB/GiB), which differs from the Kubernetes quantity above.
   goMemLimit: "1280MiB"
+  # ClusterRole + ClusterRoleBinding for the agent's API access (see informers
+  # below). Set create=false to manage them out of band — e.g. restricted
+  # clusters (OpenShift, strict namespace isolation) where the installing user
+  # can't create cluster-scoped resources and an admin pre-creates them.
+  rbac:
+    create: true
   # In-process metadata: the agent watches the Kubernetes API via informers and
   # synthesizes the kube_* object metadata itself (no kube-state-metrics). This
   # requires the ClusterRole in templates/agent/agent-rbac.yaml (get/list/watch

--- a/charts/digiusher-k8s-agent/values.yaml
+++ b/charts/digiusher-k8s-agent/values.yaml
@@ -71,12 +71,32 @@ agent:
       memory: 128Mi
     limits:
       cpu: 2000m
-      memory: 640Mi
+      memory: 1536Mi
   # Soft Go heap ceiling. Paces GC to keep resident memory bounded well under
   # the limit above, giving the container a flat, predictable footprint instead
   # of one that grows with load. Keep it below limits.memory with headroom. Uses
   # Go's size format (MiB/GiB), which differs from the Kubernetes quantity above.
-  goMemLimit: "460MiB"
+  goMemLimit: "1280MiB"
+  # In-process metadata: the agent watches the Kubernetes API via informers and
+  # synthesizes the kube_* object metadata itself (no kube-state-metrics). This
+  # requires the ClusterRole in templates/agent/agent-rbac.yaml (get/list/watch
+  # on the watched kinds), bound to the agent ServiceAccount.
+  informers:
+    # Seconds between metadata snapshots emitted to the stream (clamped 15–300).
+    emitIntervalSeconds: 60
+    # Annotation keys to collect for cost allocation (comma-separated). Match the
+    # keys your org tags with for chargeback; empty collects none. Avoid
+    # high-cardinality keys (e.g. last-applied-configuration) — they explode
+    # series count.
+    annotationKeys: "team,cost-center,owner"
+    # Comma-separated resource kinds to stop watching (plural lowercase, e.g.
+    # "poddisruptionbudgets,horizontalpodautoscalers"). Empty watches all.
+    disabledKinds: ""
+    # Path to a kubeconfig for the metadata client. Empty uses the in-cluster
+    # config (the pod ServiceAccount) — the norm for an in-cluster install.
+    kubeconfig: ""
+    # Export the KSM-parity debug endpoint (/debug/ksm-parity). Diagnostics only.
+    enableParityExport: false
   env:
     # Required — provided by the DigiUsher team. Secret only renders when this
     # is non-empty; the agent fails fast on startup if the env var is missing.
@@ -139,9 +159,11 @@ agent:
 #########################################
 # vmagent (VictoriaMetrics agent) configurations
 #
-# vmagent runs as a single Deployment that scrapes KSM + every kubelet's
-# /metrics/cadvisor and /metrics endpoints (via Kubernetes service discovery),
-# then remote_writes to the in-cluster agent Service.
+# vmagent runs as a single Deployment that scrapes every kubelet's
+# /metrics/cadvisor and /metrics endpoints (plus optional dcgm-exporter and
+# node-exporter) via Kubernetes service discovery, then remote_writes to the
+# in-cluster agent Service. Object metadata no longer comes from a scrape — the
+# agent synthesizes it in-process from the Kubernetes API.
 #########################################
 vmagent:
   enabled: true
@@ -156,15 +178,9 @@ vmagent:
   # pods (jobs, scaling churn) — at 60s a 15-second pod has only ~25% chance
   # of being captured in a scrape; at 20s the capture probability is ~75%.
   # vmagent's own footprint is series-driven, not scrape-rate-driven, so a
-  # lower cAdvisor interval barely moves the scraper's memory or CPU.
-  #
-  # Tighten KSM (e.g. ~20–30s) to catch short-lived pods/jobs before they
-  # vanish — the agent's change-detection keeps downstream volume bounded, so a
-  # faster KSM scrape costs API-server read load, not downstream samples.
-  # Validate kube-apiserver headroom before going low. kubelet stays at 60s;
-  # storage capacity changes slowly.
+  # lower cAdvisor interval barely moves the scraper's memory or CPU. kubelet
+  # stays at 60s; storage capacity changes slowly.
   intervals:
-    ksm: "60s"
     cadvisor: "60s"
     kubelet: "60s"
   # GPU metrics via dcgm-exporter, for GPU cost/utilization. ON by default:
@@ -244,36 +260,3 @@ vmagent:
       value: "true"
       effect: "NoSchedule"
   affinity: {}
-
-#########################################
-# Kube State Metrics configurations
-#########################################
-kube-state-metrics:
-  # Memory request only; the limit is left unset — set one sized to your
-  # cluster if you want a hard ceiling.
-  # KSM memory scales with cluster object count.
-  resources:
-    requests:
-      cpu: 50m
-      memory: 128Mi
-  # Soft Go heap ceiling for kube-state-metrics. KSM allocates a large heap
-  # during its initial LIST of all cluster objects on startup and settles
-  # afterward; GOMEMLIMIT paces GC so that startup spike stays bounded instead
-  # of briefly peaking well above steady state. Size it ABOVE your steady-state
-  # KSM usage (which grows with object count) with headroom — set too low it
-  # drives GC CPU up. Remove this entry to leave KSM's heap uncapped.
-  env:
-    - name: GOMEMLIMIT
-      value: "1GiB"
-  extraArgs:
-    - "--metric-labels-allowlist=pods=[*],nodes=[*],services=[selector],resourcequotas=[*],jobs=[*],namespaces=[*],endpoints=[*]"
-    # Annotation-based cost allocation. KSM emits no annotations by default;
-    # this surfaces the keys your org tags with for chargeback. Set the keys to
-    # match your conventions (cost-center / team / owner, etc.). Do NOT use
-    # [*] — it pulls in huge annotations like
-    # kubectl.kubernetes.io/last-applied-configuration and explodes cardinality.
-    # Overriding extraArgs replaces the whole list, so keep the line above too.
-    - "--metric-annotations-allowlist=pods=[team,cost-center,owner],namespaces=[team,cost-center,owner]"
-  podLabels:
-    owner: digiusher-k8s
-    component: external


### PR DESCRIPTION
The agent now watches the Kubernetes API directly and synthesizes the `kube_*` object metadata in-process, so the bundled kube-state-metrics dependency and its scrape job are removed. This PR also documents the chart's configurable values, adds resource-sizing guidance, and broadens the cost-metric collection surface.

## Changes
- **Chart.yaml**: remove the `kube-state-metrics` dependency; chart `0.5.0`, appVersion `1.2.0`.
- **values.yaml**:
  - drop the `kube-state-metrics` block; add an `agent.informers` block (emit interval, annotation keys, disabled kinds, kubeconfig, parity export); raise the agent memory request/limit and `GOMEMLIMIT` to match the in-process metadata footprint.
  - add a *Resource sizing across cluster sizes* section — the agent's memory is flat and does not scale with cluster size (it streams to disk and paces its heap with `GOMEMLIMIT`), so the default fits any cluster as-is; vmagent is the series-driven component to size up on large clusters (raise `memoryAllowedBytes`, optionally set a memory limit). Cross-referenced at each resource stanza.
- **New `agent-rbac.yaml`**: ClusterRole + ClusterRoleBinding granting `get/list/watch` on the watched kinds, bound to the agent ServiceAccount.
- **agent ConfigMap**: emits the informer settings.
- **vmagent ConfigMap**:
  - remove the kube-state-metrics scrape job; cAdvisor, kubelet, dcgm-exporter and node-exporter scraping unchanged.
  - extend the cAdvisor + node-exporter keep-lists with cost-relevant series: `container_fs_usage_bytes` / `container_fs_limit_bytes` (ephemeral / local-disk usage + limit; the `device` label is kept for these per-device series and is absent on the cpu/memory/network families) and `node_disk_io_time_seconds_total` / `node_disk_reads_completed_total` / `node_disk_writes_completed_total` (disk IOPS / busy-time — the cost driver for provisioned-IOPS volumes).
- **New chart `README.md`**: documents the configurable values (agent, informers, vmagent, optional dcgm / node-exporter) in a Key / Description / Default table, with install steps and a sizing section — so users don't have to read `values.yaml` to find what's tunable.

## Validation
- `helm lint` + `helm template` clean (no kube-state-metrics manifests rendered).
- Installed on a test cluster: the agent syncs all watched kinds with no degraded kinds, both data streams flow, memory stays flat across a multi-hour run, and parquet uploads succeed end-to-end — including the new keep-list series, confirmed flowing through to ingestion.

## Release dependency
Requires the agent `1.2.0` image (in-process metadata + the matching usage classification for the new keep-list series). The chart's appVersion already pins `1.2.0`, so once that image is published this chart needs no further version change.
